### PR TITLE
fix: data race, goroutine leak and invalid concurrency handling

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26.2'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -27,6 +27,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.26.2'
     - name: Test
       run: make test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,9 +17,7 @@ jobs:
         with:
           go-version: '1.26.2'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
+        uses: golangci/golangci-lint-action@v7
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ilkamo/polipo
 
-go 1.23
+go 1.26.2
 
 require github.com/stretchr/testify v1.9.0
 

--- a/options_test.go
+++ b/options_test.go
@@ -16,4 +16,18 @@ func TestWithMaxConcurrency(t *testing.T) {
 		)
 		require.Equal(t, maxConcurrency, p.maxConcurrency)
 	})
+
+	t.Run("should clamp zero to 1", func(t *testing.T) {
+		p := NewPolipo[result](
+			WithMaxConcurrency[result](0),
+		)
+		require.Equal(t, 1, p.maxConcurrency)
+	})
+
+	t.Run("should clamp negative to 1", func(t *testing.T) {
+		p := NewPolipo[result](
+			WithMaxConcurrency[result](-5),
+		)
+		require.Equal(t, 1, p.maxConcurrency)
+	})
 }

--- a/polipo.go
+++ b/polipo.go
@@ -20,7 +20,6 @@ type Polipo[T any] struct {
 	tasks             []Task[T]     // tasks is a list of Tasks to be run concurrently.
 	maxConcurrency    int           // maxConcurrency is the maximum number of concurrent tasks to run.
 	concurrencyBuffer chan struct{} // concurrencyBuffer is used to limit the number of concurrent tasks.
-	processing        bool          // processing is used to prevent adding tasks while Do is running.
 }
 
 // NewPolipo creates a new Polipo. It accepts options to configure the Polipo.
@@ -35,6 +34,10 @@ func NewPolipo[T any](opts ...Option[T]) *Polipo[T] {
 
 	for _, opt := range opts {
 		opt(&p)
+	}
+
+	if p.maxConcurrency < 1 {
+		p.maxConcurrency = 1
 	}
 
 	p.concurrencyBuffer = make(chan struct{}, p.maxConcurrency)
@@ -59,28 +62,30 @@ func (p *Polipo[T]) AddTask(task Task[T]) {
 // set by passing `WithMaxConcurrency` as an option. The default is 10.
 // This is a blocking function that will return when all the Tasks have finished their work.
 func (p *Polipo[T]) Do(ctx context.Context) ([]T, error) {
+	p.Lock()
+	defer p.Unlock()
+
 	if len(p.tasks) == 0 {
 		return nil, errors.New("no tasks to do")
 	}
 
-	p.Lock()
-	defer func() {
-		p.processing = false
-		p.Unlock()
-	}()
-
-	p.processing = true
-
 	processedChan := make(chan processed[T])
 	wg := sync.WaitGroup{}
-
-	wg.Add(len(p.tasks))
+	schedulerDone := make(chan struct{})
 
 	// Schedule tasks to run concurrently limiting the number of concurrent tasks.
 	go func() {
+		defer close(schedulerDone)
+
 		for _, task := range p.tasks {
-			// Wait for an available slot in the concurrencyBuffer.
-			<-p.concurrencyBuffer
+			// Wait for an available slot or context cancellation.
+			select {
+			case <-p.concurrencyBuffer:
+			case <-ctx.Done():
+				return
+			}
+
+			wg.Add(1)
 
 			go func(t Task[T]) {
 				defer wg.Done()
@@ -97,8 +102,9 @@ func (p *Polipo[T]) Do(ctx context.Context) ([]T, error) {
 		}
 	}()
 
-	// Wait for all tasks to finish.
+	// Wait for all launched tasks to finish.
 	go func() {
+		<-schedulerDone
 		wg.Wait()
 		close(processedChan)
 	}()

--- a/polipo_test.go
+++ b/polipo_test.go
@@ -96,7 +96,9 @@ func TestPolipo_Do(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				ctx := context.TODO()
 
-				p := polipo.NewPolipo[TaskResult]()
+				p := polipo.NewPolipo[TaskResult](
+					polipo.WithMaxConcurrency[TaskResult](tc.concurrency),
+				)
 
 				for _, task := range tasks {
 					p.AddTask(task)


### PR DESCRIPTION
Move lock acquisition before len(p.tasks) check to prevent a data race, stop scheduling new tasks on context cancellation to prevent goroutine leaks, clamp WithMaxConcurrency to minimum 1 to prevent deadlock, remove unused processing field, and fix test to actually use concurrency param.